### PR TITLE
fix: filter topic detail hot topics by request audience

### DIFF
--- a/app/http/controllers/forum/access_control.go
+++ b/app/http/controllers/forum/access_control.go
@@ -28,6 +28,19 @@ func requestAccessSnapshot(c *gin.Context) (accesscontrol.Snapshot, bool) {
 	return snapshot, true
 }
 
+// cachedAccessSnapshot returns the snapshot the handler already resolved for this
+// request. It never resolves nor aborts, so payload builders can stay side-effect
+// free; when no handler resolved one it falls back to the empty snapshot, which
+// reads as "nothing is readable" and keeps the caller fail-closed.
+func cachedAccessSnapshot(c *gin.Context) accesscontrol.Snapshot {
+	if value, ok := c.Get(accessSnapshotContextKey); ok {
+		if snapshot, valid := value.(accesscontrol.Snapshot); valid {
+			return snapshot
+		}
+	}
+	return accesscontrol.Snapshot{}
+}
+
 func redirectGuestToLogin(c *gin.Context) {
 	c.Redirect(http.StatusFound, "/login?redirect="+url.QueryEscape(c.Request.URL.String()))
 }

--- a/app/http/controllers/forum/payload.go
+++ b/app/http/controllers/forum/payload.go
@@ -1005,7 +1005,7 @@ func buildTopicDetailProps(c *gin.Context, topic *topics.Entity, firstPost *post
 			topic.PostSeq,
 			0,
 		),
-		HotTopics: buildTopicHotTopics(topic.Id),
+		HotTopics: buildTopicHotTopics(c, topic.Id),
 		Permissions: TopicPermissions{
 			IsOwnTopic:       currentUserID == topic.UserId,
 			CanPost:          currentUserID > 0,
@@ -1162,8 +1162,17 @@ func buildReplyTargetPayload(topicID, postID uint64, postMap map[uint64]*posts.E
 	return target
 }
 
-func buildTopicHotTopics(currentTopicID uint64) []TopicPayload {
-	topicPage := hotdataserve.GetLatestTopicsSimpleVoPaginated(1, "hot")
+func buildTopicHotTopics(c *gin.Context, currentTopicID uint64) []TopicPayload {
+	snapshot := cachedAccessSnapshot(c)
+	audience, cacheable := snapshot.ListCacheAudience()
+	topicPage := hotdataserve.GetLatestTopicsSimpleVoPaginatedForAudience(
+		1,
+		"hot",
+		audience,
+		snapshot.ReadableCategoryIDs(),
+		!snapshot.HasGlobalManage(),
+		cacheable,
+	)
 	filtered := make([]*vo.TopicsSimpleVo, 0, 6)
 	for _, topic := range topicPage.Topics {
 		if topic == nil || topic.Id == currentTopicID {

--- a/app/http/controllers/forum/topic_hot_topics_test.go
+++ b/app/http/controllers/forum/topic_hot_topics_test.go
@@ -1,0 +1,114 @@
+package forum
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/leancodebox/GooseForum/app/bundles/connect/dbconnect"
+	"github.com/leancodebox/GooseForum/app/models/forum/accessGroups"
+	"github.com/leancodebox/GooseForum/app/models/forum/categoryGroupPermissions"
+	"github.com/leancodebox/GooseForum/app/models/forum/topicCategoryIndex"
+	"github.com/leancodebox/GooseForum/app/models/forum/topics"
+	"github.com/leancodebox/GooseForum/app/models/forum/users"
+	"github.com/leancodebox/GooseForum/app/models/hotdataserve"
+	"github.com/leancodebox/GooseForum/app/service/accesscontrol"
+)
+
+func TestBuildTopicHotTopicsHidesRestrictedTopicsFromGuests(t *testing.T) {
+	const (
+		publicCategoryID     = uint64(994201)
+		restrictedCategoryID = uint64(994202)
+		publicTopicID        = uint64(994210)
+		restrictedTopicID    = uint64(994211)
+		authorID             = uint64(994220)
+	)
+
+	conn := dbconnect.Connect()
+	if err := conn.AutoMigrate(&topics.Entity{}, &topicCategoryIndex.Entity{}, &users.EntityComplete{}); err != nil {
+		t.Fatalf("migrate hot topics tables: %v", err)
+	}
+	ensureForumTestAccessCategory(t, publicCategoryID)
+	ensureForumTestAccessCategory(t, restrictedCategoryID)
+	revokeForumTestEveryoneRead(t, restrictedCategoryID)
+
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	conn.Unscoped().Delete(&users.EntityComplete{}, authorID)
+	conn.Unscoped().Delete(&topics.Entity{}, []uint64{publicTopicID, restrictedTopicID})
+	conn.Where("topic_id in ?", []uint64{publicTopicID, restrictedTopicID}).Delete(&topicCategoryIndex.Entity{})
+	t.Cleanup(func() {
+		conn.Unscoped().Delete(&users.EntityComplete{}, authorID)
+		conn.Unscoped().Delete(&topics.Entity{}, []uint64{publicTopicID, restrictedTopicID})
+		conn.Where("topic_id in ?", []uint64{publicTopicID, restrictedTopicID}).Delete(&topicCategoryIndex.Entity{})
+		hotdataserve.ClearTopicListCache()
+		hotdataserve.ClearTopicCategoryCache()
+	})
+
+	conn.Create(&users.EntityComplete{Id: authorID, Username: "hot-topics-author"})
+	// The reply counts put both topics at the top of the "hot" ordering, restricted first.
+	conn.Create(&topics.Entity{
+		Id: publicTopicID, Title: "public hot topic", CategoryIds: []uint64{publicCategoryID},
+		UserId: authorID, Status: 1, ProcessStatus: 0, ReplyCount: 900001, CreatedAt: now, UpdatedAt: now,
+	})
+	conn.Create(&topics.Entity{
+		Id: restrictedTopicID, Title: "restricted hot topic", CategoryIds: []uint64{restrictedCategoryID},
+		UserId: authorID, Status: 1, ProcessStatus: 0, ReplyCount: 900002, CreatedAt: now, UpdatedAt: now,
+	})
+	conn.Create(&topicCategoryIndex.Entity{TopicId: publicTopicID, CategoryId: publicCategoryID, Effective: 1})
+	conn.Create(&topicCategoryIndex.Entity{TopicId: restrictedTopicID, CategoryId: restrictedCategoryID, Effective: 1})
+	hotdataserve.ClearTopicListCache()
+	hotdataserve.ClearTopicCategoryCache()
+
+	guest, err := accesscontrol.Resolve(0)
+	if err != nil {
+		t.Fatalf("resolve guest snapshot: %v", err)
+	}
+	if guest.CanReadCategory(restrictedCategoryID) {
+		t.Fatal("test setup: guests must not be able to read the restricted category")
+	}
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/t/topic/994210", nil)
+	c.Set(accessSnapshotContextKey, guest)
+
+	hotTopics := buildTopicHotTopics(c, 0)
+
+	sawPublic := false
+	for _, item := range hotTopics {
+		if item.ID == restrictedTopicID {
+			t.Fatalf("hot topics leaked restricted topic %q to a guest", item.Title)
+		}
+		if item.ID == publicTopicID {
+			sawPublic = true
+		}
+	}
+	if !sawPublic {
+		t.Fatalf("hot topics dropped the readable topic: %#v", hotTopics)
+	}
+}
+
+// revokeForumTestEveryoneRead turns a category created by ensureForumTestAccessCategory
+// into a restricted one by dropping the everyone group's grant on it.
+func revokeForumTestEveryoneRead(t *testing.T, categoryID uint64) {
+	t.Helper()
+	conn := dbconnect.Connect()
+	groups, err := accessGroups.GetBySystemKeys([]string{accessGroups.SystemKeyEveryone})
+	if err != nil {
+		t.Fatalf("load everyone access group: %v", err)
+	}
+	if len(groups) == 0 {
+		t.Fatal("everyone access group missing after backfill")
+	}
+	for _, group := range groups {
+		if err := conn.Where("category_id = ? and access_group_id = ?", categoryID, group.Id).
+			Delete(&categoryGroupPermissions.Entity{}).Error; err != nil {
+			t.Fatalf("revoke everyone grant: %v", err)
+		}
+		accesscontrol.InvalidateGroup(group.Id)
+	}
+	accesscontrol.InvalidateSystemGroups()
+}


### PR DESCRIPTION
First of the three blockers from https://github.com/leancodebox/GooseForum/issues/12#issuecomment-5256798517. Targets `feature/category-access-control`, not `main`.

## The problem

`buildTopicHotTopics` was the last caller of `hotdataserve.GetLatestTopicsSimpleVoPaginated` — the pre-branch unfiltered wrapper, which passes `filterAudience=false` and caches under the `public` audience key. It renders into every topic detail page, so any visitor including a logged-out one got up to six hot topics with title, author and link, restricted ones among them.

## The fix

`buildTopicHotTopics` now takes the `*gin.Context` and goes through `GetLatestTopicsSimpleVoPaginatedForAudience` with exactly the arguments `Home` already uses. `TopicDetail` resolves the snapshot at `topic.go:43` before it builds the payload, so this is a context lookup, not a second resolve. Guest topic-detail sidebars and the guest homepage now land on the same cache key and share one entry.

The new `cachedAccessSnapshot` helper reads the snapshot out of the gin context without resolving and without aborting. I did not reuse `requestAccessSnapshot` here on purpose: a payload builder should not be able to emit a 503 halfway through building a payload. When no handler resolved a snapshot it returns the empty one, which reads as "nothing is readable" — so the failure mode is an empty sidebar, never a leak.

## Test

`TestBuildTopicHotTopicsHidesRestrictedTopicsFromGuests` builds a restricted category, puts a topic in it ranked first by `reply_count` under the `hot` sort, resolves a real guest snapshot, and asserts the restricted topic is absent while the readable one is still there. Reverting only the `payload.go` change makes it fail with `hot topics leaked restricted topic "restricted hot topic" to a guest`, so it is a real regression test and not a tautology.

`go build ./...` is clean and the full `go test ./...` passes.

## One thing I deliberately left alone

After this change `GetLatestTopicsSimpleVoPaginated` is called only from `topic_list_cache_test.go`. Keeping it is defensible, but it is exactly the footgun that produced this bug: an exported, unfiltered read helper sitting next to the filtered one. I am happy to delete it here or in a follow-up — I left it in so this PR stays one fix. Your call.

---

这是 https://github.com/leancodebox/GooseForum/issues/12#issuecomment-5256798517 里三个阻塞项中的第一个。目标分支是 `feature/category-access-control`，不是 `main`。

## 问题

`buildTopicHotTopics` 是 `hotdataserve.GetLatestTopicsSimpleVoPaginated` 最后一个调用方——那是本分支之前的未过滤封装，它传入 `filterAudience=false`，并缓存在 `public` 这个 audience key 下。它会渲染进每一个主题详情页，因此任何访客（包括未登录的）都能拿到最多六条热门主题的标题、作者和链接，其中就包含受限主题。

## 修改

`buildTopicHotTopics` 现在接收 `*gin.Context`，并改走 `GetLatestTopicsSimpleVoPaginatedForAudience`，参数与 `Home` 现有的用法完全一致。`TopicDetail` 在构建 payload 之前已经在 `topic.go:43` 解析过快照，所以这里只是一次 context 读取，不会重复解析。访客的详情页侧栏和访客首页现在落在同一个缓存 key 上，共用一份缓存。

新增的 `cachedAccessSnapshot` 只从 gin context 里读取快照，不解析、也不 abort。我特意没有在这里复用 `requestAccessSnapshot`：payload 构建函数不应该有能力在构建到一半时抛出 503。当没有任何 handler 解析过快照时，它返回空快照，语义是"什么都不可读"——所以失败时的表现是侧栏为空，而绝不会是泄露。

## 测试

`TestBuildTopicHotTopicsHidesRestrictedTopicsFromGuests` 会建立一个受限分类，在其中放一个按 `reply_count` 在 `hot` 排序下排第一的主题，解析一个真实的访客快照，然后断言受限主题不出现、可读主题仍然出现。只回退 `payload.go` 的改动，这个测试就会以 `hot topics leaked restricted topic "restricted hot topic" to a guest` 失败——所以它是一个真正的回归测试，而不是一个恒真断言。

`go build ./...` 通过，完整的 `go test ./...` 也全部通过。

## 有一处我故意没动

改完之后，`GetLatestTopicsSimpleVoPaginated` 就只剩 `topic_list_cache_test.go` 在调用了。保留它也说得通，但它正是造成这个 bug 的隐患：一个导出的、未过滤的读取函数，就摆在过滤版本旁边。我可以在这个 PR 里删掉它，也可以放到后续 PR——我先留着，让这个 PR 只做一件事。你决定就好。
