### PR TITLE
fix: close the two conversion blockers inside the current model

### DIFF
--- a/app/http/controllers/forum/access_control.go
+++ b/app/http/controllers/forum/access_control.go
@@ -28,6 +28,19 @@ func requestAccessSnapshot(c *gin.Context) (accesscontrol.Snapshot, bool) {
 	return snapshot, true
 }
 
+// cachedAccessSnapshot returns the snapshot the handler already resolved for this
+// request. It never resolves nor aborts, so payload builders can stay side-effect
+// free; when no handler resolved one it falls back to the empty snapshot, which
+// reads as "nothing is readable" and keeps the caller fail-closed.
+func cachedAccessSnapshot(c *gin.Context) accesscontrol.Snapshot {
+	if value, ok := c.Get(accessSnapshotContextKey); ok {
+		if snapshot, valid := value.(accesscontrol.Snapshot); valid {
+			return snapshot
+		}
+	}
+	return accesscontrol.Snapshot{}
+}
+
 func redirectGuestToLogin(c *gin.Context) {
 	c.Redirect(http.StatusFound, "/login?redirect="+url.QueryEscape(c.Request.URL.String()))
 }

--- a/app/http/controllers/forum/payload.go
+++ b/app/http/controllers/forum/payload.go
@@ -1005,7 +1005,7 @@ func buildTopicDetailProps(c *gin.Context, topic *topics.Entity, firstPost *post
 			topic.PostSeq,
 			0,
 		),
-		HotTopics: buildTopicHotTopics(topic.Id),
+		HotTopics: buildTopicHotTopics(c, topic.Id),
 		Permissions: TopicPermissions{
 			IsOwnTopic:       currentUserID == topic.UserId,
 			CanPost:          currentUserID > 0,
@@ -1162,8 +1162,17 @@ func buildReplyTargetPayload(topicID, postID uint64, postMap map[uint64]*posts.E
 	return target
 }
 
-func buildTopicHotTopics(currentTopicID uint64) []TopicPayload {
-	topicPage := hotdataserve.GetLatestTopicsSimpleVoPaginated(1, "hot")
+func buildTopicHotTopics(c *gin.Context, currentTopicID uint64) []TopicPayload {
+	snapshot := cachedAccessSnapshot(c)
+	audience, cacheable := snapshot.ListCacheAudience()
+	topicPage := hotdataserve.GetLatestTopicsSimpleVoPaginatedForAudience(
+		1,
+		"hot",
+		audience,
+		snapshot.ReadableCategoryIDs(),
+		!snapshot.HasGlobalManage(),
+		cacheable,
+	)
 	filtered := make([]*vo.TopicsSimpleVo, 0, 6)
 	for _, topic := range topicPage.Topics {
 		if topic == nil || topic.Id == currentTopicID {

--- a/app/http/controllers/forum/topic_hot_topics_test.go
+++ b/app/http/controllers/forum/topic_hot_topics_test.go
@@ -1,0 +1,114 @@
+package forum
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/leancodebox/GooseForum/app/bundles/connect/dbconnect"
+	"github.com/leancodebox/GooseForum/app/models/forum/accessGroups"
+	"github.com/leancodebox/GooseForum/app/models/forum/categoryGroupPermissions"
+	"github.com/leancodebox/GooseForum/app/models/forum/topicCategoryIndex"
+	"github.com/leancodebox/GooseForum/app/models/forum/topics"
+	"github.com/leancodebox/GooseForum/app/models/forum/users"
+	"github.com/leancodebox/GooseForum/app/models/hotdataserve"
+	"github.com/leancodebox/GooseForum/app/service/accesscontrol"
+)
+
+func TestBuildTopicHotTopicsHidesRestrictedTopicsFromGuests(t *testing.T) {
+	const (
+		publicCategoryID     = uint64(994201)
+		restrictedCategoryID = uint64(994202)
+		publicTopicID        = uint64(994210)
+		restrictedTopicID    = uint64(994211)
+		authorID             = uint64(994220)
+	)
+
+	conn := dbconnect.Connect()
+	if err := conn.AutoMigrate(&topics.Entity{}, &topicCategoryIndex.Entity{}, &users.EntityComplete{}); err != nil {
+		t.Fatalf("migrate hot topics tables: %v", err)
+	}
+	ensureForumTestAccessCategory(t, publicCategoryID)
+	ensureForumTestAccessCategory(t, restrictedCategoryID)
+	revokeForumTestEveryoneRead(t, restrictedCategoryID)
+
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	conn.Unscoped().Delete(&users.EntityComplete{}, authorID)
+	conn.Unscoped().Delete(&topics.Entity{}, []uint64{publicTopicID, restrictedTopicID})
+	conn.Where("topic_id in ?", []uint64{publicTopicID, restrictedTopicID}).Delete(&topicCategoryIndex.Entity{})
+	t.Cleanup(func() {
+		conn.Unscoped().Delete(&users.EntityComplete{}, authorID)
+		conn.Unscoped().Delete(&topics.Entity{}, []uint64{publicTopicID, restrictedTopicID})
+		conn.Where("topic_id in ?", []uint64{publicTopicID, restrictedTopicID}).Delete(&topicCategoryIndex.Entity{})
+		hotdataserve.ClearTopicListCache()
+		hotdataserve.ClearTopicCategoryCache()
+	})
+
+	conn.Create(&users.EntityComplete{Id: authorID, Username: "hot-topics-author"})
+	// The reply counts put both topics at the top of the "hot" ordering, restricted first.
+	conn.Create(&topics.Entity{
+		Id: publicTopicID, Title: "public hot topic", CategoryIds: []uint64{publicCategoryID},
+		UserId: authorID, Status: 1, ProcessStatus: 0, ReplyCount: 900001, CreatedAt: now, UpdatedAt: now,
+	})
+	conn.Create(&topics.Entity{
+		Id: restrictedTopicID, Title: "restricted hot topic", CategoryIds: []uint64{restrictedCategoryID},
+		UserId: authorID, Status: 1, ProcessStatus: 0, ReplyCount: 900002, CreatedAt: now, UpdatedAt: now,
+	})
+	conn.Create(&topicCategoryIndex.Entity{TopicId: publicTopicID, CategoryId: publicCategoryID, Effective: 1})
+	conn.Create(&topicCategoryIndex.Entity{TopicId: restrictedTopicID, CategoryId: restrictedCategoryID, Effective: 1})
+	hotdataserve.ClearTopicListCache()
+	hotdataserve.ClearTopicCategoryCache()
+
+	guest, err := accesscontrol.Resolve(0)
+	if err != nil {
+		t.Fatalf("resolve guest snapshot: %v", err)
+	}
+	if guest.CanReadCategory(restrictedCategoryID) {
+		t.Fatal("test setup: guests must not be able to read the restricted category")
+	}
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/t/topic/994210", nil)
+	c.Set(accessSnapshotContextKey, guest)
+
+	hotTopics := buildTopicHotTopics(c, 0)
+
+	sawPublic := false
+	for _, item := range hotTopics {
+		if item.ID == restrictedTopicID {
+			t.Fatalf("hot topics leaked restricted topic %q to a guest", item.Title)
+		}
+		if item.ID == publicTopicID {
+			sawPublic = true
+		}
+	}
+	if !sawPublic {
+		t.Fatalf("hot topics dropped the readable topic: %#v", hotTopics)
+	}
+}
+
+// revokeForumTestEveryoneRead turns a category created by ensureForumTestAccessCategory
+// into a restricted one by dropping the everyone group's grant on it.
+func revokeForumTestEveryoneRead(t *testing.T, categoryID uint64) {
+	t.Helper()
+	conn := dbconnect.Connect()
+	groups, err := accessGroups.GetBySystemKeys([]string{accessGroups.SystemKeyEveryone})
+	if err != nil {
+		t.Fatalf("load everyone access group: %v", err)
+	}
+	if len(groups) == 0 {
+		t.Fatal("everyone access group missing after backfill")
+	}
+	for _, group := range groups {
+		if err := conn.Where("category_id = ? and access_group_id = ?", categoryID, group.Id).
+			Delete(&categoryGroupPermissions.Entity{}).Error; err != nil {
+			t.Fatalf("revoke everyone grant: %v", err)
+		}
+		accesscontrol.InvalidateGroup(group.Id)
+	}
+	accesscontrol.InvalidateSystemGroups()
+}

--- a/app/service/accessadminservice/access_admin.go
+++ b/app/service/accessadminservice/access_admin.go
@@ -286,6 +286,14 @@ func ReviewApplication(groupID, memberID uint64, approve bool) error {
 	return ErrInvalidMember
 }
 
+// testHookBeforeRestrictionTx lets a test interleave a concurrent write between
+// the preview and the transaction, which is exactly the window this code has to
+// be correct across. It is nil outside tests.
+var testHookBeforeRestrictionTx func()
+
+// PreviewRestriction sizes a pending conversion for the operator. It is not the
+// decision: the conversion is decided again inside the transaction, on locked
+// rows, because a topic can be created or edited into conflict in between.
 func PreviewRestriction(categoryID uint64) (int, error) {
 	var count int64
 	err := restrictionConflictQuery(dbconnect.Connect(), categoryID).Count(&count).Error
@@ -312,25 +320,41 @@ func ReplaceCategoryGrants(categoryID uint64, grants []GrantInput, strategy stri
 	}
 	wasPublic := enabledLevel(existing, everyoneID) >= categoryGroupPermissions.PermissionRead
 	willBePublic := canonical[everyoneID] >= categoryGroupPermissions.PermissionRead
-	conflictCount := 0
-	if wasPublic && !willBePublic {
-		conflictCount, err = PreviewRestriction(categoryID)
+	restricting := wasPublic && !willBePublic
+	if restricting {
+		// Fail early and cheaply so the operator gets the strategy prompt or the
+		// size error without opening a transaction.
+		previewCount, err := PreviewRestriction(categoryID)
 		if err != nil {
 			return err
 		}
-		if conflictCount > MaxRestrictionConversionTopics {
+		if previewCount > MaxRestrictionConversionTopics {
 			return ErrRestrictionTooLarge
 		}
-		if conflictCount > 0 && strategy != RestrictionKeepCategory && strategy != RestrictionRemoveCategory {
-			return RestrictionConflictError{Count: conflictCount}
+		if previewCount > 0 && !validRestrictionStrategy(strategy) {
+			return RestrictionConflictError{Count: previewCount}
 		}
 	}
 
+	if testHookBeforeRestrictionTx != nil {
+		testHookBeforeRestrictionTx()
+	}
+
 	err = dbconnect.Connect().Transaction(func(tx *gorm.DB) error {
-		if conflictCount > 0 {
+		if restricting {
 			var affected []topics.Entity
 			if err := restrictionConflictQuery(tx.Clauses(clause.Locking{Strength: "UPDATE"}), categoryID).Find(&affected).Error; err != nil {
 				return err
+			}
+			// The preview above is advisory. What the conversion acts on is this
+			// locked read, so a topic that became conflicting after the preview
+			// is either converted here or aborts the whole change — it can never
+			// be left behind as a [public, restricted] topic.
+			if len(affected) > MaxRestrictionConversionTopics {
+				return ErrRestrictionTooLarge
+			}
+			if len(affected) > 0 && !validRestrictionStrategy(strategy) {
+				return RestrictionConflictError{Count: len(affected)}
 			}
 			for i := range affected {
 				categoryIDs := convertedCategories(affected[i].CategoryIds, categoryID, strategy)
@@ -375,6 +399,10 @@ func ReplaceCategoryGrants(categoryID uint64, grants []GrantInput, strategy stri
 		accesscontrol.InvalidateGroup(grant.AccessGroupId)
 	}
 	return nil
+}
+
+func validRestrictionStrategy(strategy string) bool {
+	return strategy == RestrictionKeepCategory || strategy == RestrictionRemoveCategory
 }
 
 func restrictionConflictQuery(db *gorm.DB, categoryID uint64) *gorm.DB {

--- a/app/service/accessadminservice/access_admin.go
+++ b/app/service/accessadminservice/access_admin.go
@@ -3,6 +3,7 @@ package accessadminservice
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/leancodebox/GooseForum/app/bundles/connect/dbconnect"
@@ -10,9 +11,11 @@ import (
 	"github.com/leancodebox/GooseForum/app/models/forum/accessGroups"
 	"github.com/leancodebox/GooseForum/app/models/forum/category"
 	"github.com/leancodebox/GooseForum/app/models/forum/categoryGroupPermissions"
+	"github.com/leancodebox/GooseForum/app/models/forum/posts"
 	"github.com/leancodebox/GooseForum/app/models/forum/topicCategoryIndex"
 	"github.com/leancodebox/GooseForum/app/models/forum/topics"
 	"github.com/leancodebox/GooseForum/app/service/accesscontrol"
+	"github.com/leancodebox/GooseForum/app/service/searchservice"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -291,6 +294,15 @@ func ReviewApplication(groupID, memberID uint64, approve bool) error {
 // be correct across. It is nil outside tests.
 var testHookBeforeRestrictionTx func()
 
+// rebuildTopicSearchDocument is a variable so tests can observe reindexing
+// without a running Meilisearch.
+var rebuildTopicSearchDocument = func(topic *topics.Entity) {
+	firstPost := posts.Get(topic.FirstPostId)
+	if _, err := searchservice.BuildSingleTopicSearchDocument(topic, &firstPost); err != nil {
+		slog.Error("reindex converted topic search document", "topicId", topic.Id, "err", err)
+	}
+}
+
 // PreviewRestriction sizes a pending conversion for the operator. It is not the
 // decision: the conversion is decided again inside the transaction, on locked
 // rows, because a topic can be created or edited into conflict in between.
@@ -340,9 +352,11 @@ func ReplaceCategoryGrants(categoryID uint64, grants []GrantInput, strategy stri
 		testHookBeforeRestrictionTx()
 	}
 
+	var converted []topics.Entity
 	err = dbconnect.Connect().Transaction(func(tx *gorm.DB) error {
+		converted = nil
+		var affected []topics.Entity
 		if restricting {
-			var affected []topics.Entity
 			if err := restrictionConflictQuery(tx.Clauses(clause.Locking{Strength: "UPDATE"}), categoryID).Find(&affected).Error; err != nil {
 				return err
 			}
@@ -369,6 +383,7 @@ func ReplaceCategoryGrants(categoryID uint64, grants []GrantInput, strategy stri
 					return err
 				}
 			}
+			converted = affected
 		}
 		if err := tx.Model(&categoryGroupPermissions.Entity{}).Where("category_id = ?", categoryID).
 			Updates(map[string]any{"status": categoryGroupPermissions.StatusDisabled, "permission_level": 0}).Error; err != nil {
@@ -391,6 +406,13 @@ func ReplaceCategoryGrants(categoryID uint64, grants []GrantInput, strategy stri
 	})
 	if err != nil {
 		return err
+	}
+	// The conversion rewrote topics.category_ids, so the Meilisearch documents
+	// of those topics still carry the old category array and would keep them
+	// findable under a category they are no longer in. Reindex after the
+	// transaction commits: the search index cannot roll back with it.
+	for i := range converted {
+		rebuildTopicSearchDocument(&converted[i])
 	}
 	for groupID := range canonical {
 		accesscontrol.InvalidateGroup(groupID)

--- a/app/service/accessadminservice/access_admin_test.go
+++ b/app/service/accessadminservice/access_admin_test.go
@@ -188,6 +188,85 @@ func TestRestrictionConversionRedecidesInsideTheTransaction(t *testing.T) {
 	}
 }
 
+// Converting a topic rewrites topics.category_ids, which is the field the
+// search document mirrors. Without a reindex the document keeps the old
+// category and guest search keeps returning a topic that is now restricted.
+func TestRestrictionConversionReindexesConvertedTopics(t *testing.T) {
+	conn := dbconnect.Connect()
+	if err := conn.AutoMigrate(
+		&accessGroups.Entity{}, &accessGroupMembers.Entity{}, &categoryGroupPermissions.Entity{},
+		&category.Entity{}, &topics.Entity{}, &topicCategoryIndex.Entity{},
+	); err != nil {
+		t.Fatalf("migrate access admin tables: %v", err)
+	}
+	const restrictedCategoryID uint64 = 965001
+	const otherCategoryID uint64 = 965002
+	const topicID uint64 = 965101
+
+	original := rebuildTopicSearchDocument
+	reindexed := map[uint64][]uint64{}
+	rebuildTopicSearchDocument = func(topic *topics.Entity) {
+		reindexed[topic.Id] = append([]uint64(nil), topic.CategoryIds...)
+	}
+	conn.Unscoped().Delete(&topics.Entity{}, topicID)
+	conn.Where("topic_id = ?", topicID).Delete(&topicCategoryIndex.Entity{})
+	conn.Delete(&categoryGroupPermissions.Entity{}, "category_id in ?", []uint64{restrictedCategoryID, otherCategoryID})
+	conn.Unscoped().Delete(&category.Entity{}, []uint64{restrictedCategoryID, otherCategoryID})
+	t.Cleanup(func() {
+		rebuildTopicSearchDocument = original
+		conn.Unscoped().Delete(&topics.Entity{}, topicID)
+		conn.Where("topic_id = ?", topicID).Delete(&topicCategoryIndex.Entity{})
+		conn.Delete(&categoryGroupPermissions.Entity{}, "category_id in ?", []uint64{restrictedCategoryID, otherCategoryID})
+		conn.Unscoped().Delete(&category.Entity{}, []uint64{restrictedCategoryID, otherCategoryID})
+	})
+
+	if err := conn.Create(&[]category.Entity{
+		{Id: restrictedCategoryID, Name: "Going private"},
+		{Id: otherCategoryID, Name: "Other"},
+	}).Error; err != nil {
+		t.Fatalf("create categories: %v", err)
+	}
+	if result := datamigration.BackfillAccessControlDefaultsWithDB(conn); result.Failed != 0 {
+		t.Fatalf("backfill defaults: %s", result.LastFailed)
+	}
+	groups, err := accessGroups.GetBySystemKeys([]string{accessGroups.SystemKeyEveryone, accessGroups.SystemKeyRegistered})
+	if err != nil {
+		t.Fatalf("load system groups: %v", err)
+	}
+	groupID := func(key string) uint64 {
+		for _, group := range groups {
+			if group.SystemKey != nil && *group.SystemKey == key {
+				return group.Id
+			}
+		}
+		return 0
+	}
+	conn.Create(&topics.Entity{
+		Id: topicID, Title: "findable in the public category", UserId: 9, Status: 1,
+		CategoryIds: []uint64{restrictedCategoryID, otherCategoryID},
+	})
+	conn.Create(&[]topicCategoryIndex.Entity{
+		{TopicId: topicID, CategoryId: restrictedCategoryID, Effective: 1},
+		{TopicId: topicID, CategoryId: otherCategoryID, Effective: 1},
+	})
+
+	grants := []GrantInput{
+		{AccessGroupID: groupID(accessGroups.SystemKeyEveryone), Level: 0},
+		{AccessGroupID: groupID(accessGroups.SystemKeyRegistered), Level: categoryGroupPermissions.PermissionCreate},
+	}
+	if err := ReplaceCategoryGrants(restrictedCategoryID, grants, RestrictionKeepCategory); err != nil {
+		t.Fatalf("replace grants with conversion: %v", err)
+	}
+
+	categories, ok := reindexed[topicID]
+	if !ok {
+		t.Fatal("converted topic was never reindexed: its search document still lists the public category")
+	}
+	if !reflect.DeepEqual(categories, []uint64{restrictedCategoryID}) {
+		t.Fatalf("reindexed categories = %v, want only the restricted one", categories)
+	}
+}
+
 func TestApplicationOnlyActivatesMembershipAfterApproval(t *testing.T) {
 	conn := dbconnect.Connect()
 	if err := conn.AutoMigrate(&accessGroups.Entity{}, &accessGroupMembers.Entity{}); err != nil {

--- a/app/service/accessadminservice/access_admin_test.go
+++ b/app/service/accessadminservice/access_admin_test.go
@@ -97,6 +97,97 @@ func TestReplaceCategoryGrantsRequiresExplicitConflictConversion(t *testing.T) {
 	}
 }
 
+// A topic can be created between the conflict preview and the transaction: at
+// that moment the category is still public, so the write is perfectly legal.
+// If the conversion trusts the preview, that topic survives as a
+// [public, restricted] topic, which the rest of the design assumes cannot exist.
+func TestRestrictionConversionRedecidesInsideTheTransaction(t *testing.T) {
+	conn := dbconnect.Connect()
+	if err := conn.AutoMigrate(
+		&accessGroups.Entity{}, &accessGroupMembers.Entity{}, &categoryGroupPermissions.Entity{},
+		&category.Entity{}, &topics.Entity{}, &topicCategoryIndex.Entity{},
+	); err != nil {
+		t.Fatalf("migrate access admin tables: %v", err)
+	}
+	const restrictedCategoryID uint64 = 964001
+	const otherCategoryID uint64 = 964002
+	const lateTopicID uint64 = 964101
+
+	conn.Unscoped().Delete(&topics.Entity{}, lateTopicID)
+	conn.Where("topic_id = ?", lateTopicID).Delete(&topicCategoryIndex.Entity{})
+	conn.Delete(&categoryGroupPermissions.Entity{}, "category_id in ?", []uint64{restrictedCategoryID, otherCategoryID})
+	conn.Unscoped().Delete(&category.Entity{}, []uint64{restrictedCategoryID, otherCategoryID})
+	t.Cleanup(func() {
+		testHookBeforeRestrictionTx = nil
+		conn.Unscoped().Delete(&topics.Entity{}, lateTopicID)
+		conn.Where("topic_id = ?", lateTopicID).Delete(&topicCategoryIndex.Entity{})
+		conn.Delete(&categoryGroupPermissions.Entity{}, "category_id in ?", []uint64{restrictedCategoryID, otherCategoryID})
+		conn.Unscoped().Delete(&category.Entity{}, []uint64{restrictedCategoryID, otherCategoryID})
+	})
+
+	if err := conn.Create(&[]category.Entity{
+		{Id: restrictedCategoryID, Name: "Going private"},
+		{Id: otherCategoryID, Name: "Other"},
+	}).Error; err != nil {
+		t.Fatalf("create categories: %v", err)
+	}
+	if result := datamigration.BackfillAccessControlDefaultsWithDB(conn); result.Failed != 0 {
+		t.Fatalf("backfill defaults: %s", result.LastFailed)
+	}
+	groups, err := accessGroups.GetBySystemKeys([]string{accessGroups.SystemKeyEveryone, accessGroups.SystemKeyRegistered})
+	if err != nil {
+		t.Fatalf("load system groups: %v", err)
+	}
+	groupID := func(key string) uint64 {
+		for _, group := range groups {
+			if group.SystemKey != nil && *group.SystemKey == key {
+				return group.Id
+			}
+		}
+		return 0
+	}
+
+	// Nothing conflicts yet, so the preview inside ReplaceCategoryGrants sees 0
+	// and an empty strategy is legitimate.
+	if count, err := PreviewRestriction(restrictedCategoryID); err != nil || count != 0 {
+		t.Fatalf("preview before the race = %d, %v, want 0", count, err)
+	}
+
+	// ...and now someone posts, while the category is still public.
+	testHookBeforeRestrictionTx = func() {
+		conn.Create(&topics.Entity{
+			Id: lateTopicID, Title: "posted just before the switch", UserId: 9,
+			CategoryIds: []uint64{restrictedCategoryID, otherCategoryID}, Status: 1,
+		})
+		conn.Create(&[]topicCategoryIndex.Entity{
+			{TopicId: lateTopicID, CategoryId: restrictedCategoryID, Effective: 1},
+			{TopicId: lateTopicID, CategoryId: otherCategoryID, Effective: 1},
+		})
+	}
+
+	grants := []GrantInput{
+		{AccessGroupID: groupID(accessGroups.SystemKeyEveryone), Level: 0},
+		{AccessGroupID: groupID(accessGroups.SystemKeyRegistered), Level: categoryGroupPermissions.PermissionCreate},
+	}
+	err = ReplaceCategoryGrants(restrictedCategoryID, grants, "")
+
+	var conflict RestrictionConflictError
+	if !errors.As(err, &conflict) || conflict.Count != 1 {
+		t.Fatalf("conversion result = %v, want a conflict for the topic created during the race", err)
+	}
+	survivor := topics.GetSimple(lateTopicID)
+	if len(survivor.CategoryIds) != 2 {
+		t.Fatalf("late topic categories = %v, want it left untouched by the aborted change", survivor.CategoryIds)
+	}
+	remaining, err := categoryGroupPermissions.ByCategoryIDs([]uint64{restrictedCategoryID})
+	if err != nil {
+		t.Fatalf("load grants: %v", err)
+	}
+	if enabledLevel(remaining, groupID(accessGroups.SystemKeyEveryone)) < categoryGroupPermissions.PermissionRead {
+		t.Fatal("category was restricted even though the conversion aborted")
+	}
+}
+
 func TestApplicationOnlyActivatesMembershipAfterApproval(t *testing.T) {
 	conn := dbconnect.Connect()
 	if err := conn.AutoMigrate(&accessGroups.Entity{}, &accessGroupMembers.Entity{}); err != nil {


### PR DESCRIPTION
Blockers 2 and 3 from https://github.com/leancodebox/GooseForum/issues/12#issuecomment-5256798517, fixed **inside your model**, on top of #14.

This is deliberately the other half of a fork in the road. #15 argues that these two defects should stop existing, because both live in the conversion path and that model has no conversion path. This PR assumes you keep your model and fixes them where they are. **They are mutually exclusive: take whichever you prefer.** I built both so the choice is yours rather than mine — I did not want "the alternative isn't written yet" to be an argument for anything.

It is a draft for that reason, not because it is unfinished.

Two commits, one per blocker.

## `fix: decide restriction conversion inside the transaction`

`PreviewRestriction` ran outside the transaction and the in-transaction fixup was gated on `conflictCount > 0`. A topic created or edited between the two was never converted — and the write was perfectly legal when it happened, because the category was still public. What is left behind is a permanent `[public, restricted]` topic: the state the single-restricted-category invariant, and everything built on it, assumes cannot exist.

The preview now only sizes the operation, so the operator still gets the strategy prompt and the 10,000 limit without opening a transaction. The conversion itself acts on the locked read inside the transaction. A topic that became conflicting in between is either converted with the rest, or — if the operator confirmed against a preview of zero and so never chose a strategy — aborts the whole change, leaving the category public and the topic untouched. The operator retries and this time gets asked.

`TestRestrictionConversionRedecidesInsideTheTransaction` reproduces the race. **It needs a seam**: a `testHookBeforeRestrictionTx` function variable, nil in production, that lets the test create the conflicting topic in exactly the window between the preview and the transaction. I checked it earns its place — against the previous logic the test fails with `conversion result = <nil>`, the conversion silently succeeds and the broken topic survives. If you would rather not have a test hook in production code, say so and I will drop the hook and the test and keep the fix.

## `fix: reindex topics converted by a category restriction`

The conversion rewrote `topics.category_ids` and `topic_category_index` and never touched Meilisearch. With `keep_category` the topic ends up in the restricted category only, while its search document still carries the old public category id, so guest search keeps returning it. Every SQL path was already correct, which is what made this easy to miss.

Converted topics are now reindexed after the transaction commits, never inside it — the search index cannot roll back with the database, so reindexing early would be worse than reindexing late.

The reindex goes through a `rebuildTopicSearchDocument` function variable so the test can observe it without a running Meilisearch. That one is ordinary indirection rather than a test hook, but it is a variable and you may still dislike it.

## One thing this PR does not close

There is a residual window after the transaction commits and before `accesscontrol.InvalidateGroup` runs. On a single instance it is microseconds. On more than one instance it is up to `metadataTTL` — two minutes — because the permission snapshot cache is in-process and invalidation is not propagated between instances. During that window another instance still believes the category is public and will happily accept a new `[public, restricted]` topic.

I did not try to fix that here: it needs either cross-instance invalidation or a periodic repair pass, and both are larger decisions than a blocker fix should smuggle in. It is worth knowing about, and it is a real (small) example of the general shape — in this model, a topic's visibility is derived from state that can change underneath it.

## Verification

`go build ./...` clean, `go vet` clean, full `go test ./...` passes. Both new tests were checked to fail against the pre-fix code rather than merely passing after it.

---

阻塞项 2 和 3，来自 https://github.com/leancodebox/GooseForum/issues/12#issuecomment-5256798517，**在你的模型内部**修复，基于 #14。

这是一个岔路口的另一半，是有意为之。#15 主张这两个缺陷应该"不再存在"，因为它们都位于转换路径上，而那个模型根本没有转换路径。本 PR 则假设你保留你的模型，就地修复它们。**两者互斥：你喜欢哪个就用哪个。** 我把两边都写出来，是为了让选择权在你手上，而不是在我手上——我不希望"另一个方案还没写"成为任何一方的论据。

它是 draft，原因就是这个，而不是因为它没做完。

两个提交，一个阻塞项一个。

## `fix: decide restriction conversion inside the transaction`

`PreviewRestriction` 在事务之外运行，而事务内的修复以 `conflictCount > 0` 为开关。在这两者之间被创建或编辑的主题永远不会被转换——而且那次写入在当时是完全合法的，因为分类那时还是公开的。留下来的是一个永久的 `[公开, 受限]` 主题：也就是"受限主题只能单分类"这条不变量、以及建立在它之上的一切所假设的、不可能存在的状态。

现在预览只负责给操作者估算规模，因此操作者依然能在不开启事务的情况下拿到策略提示和 10,000 上限。转换本身作用于事务内的加锁读取。在中途变成冲突的主题，要么和其他主题一起被转换，要么——如果操作者是基于"零冲突"的预览确认的、因而从未选择过策略——中止整个变更，分类保持公开，主题保持原样。操作者重试，这一次就会被询问。

`TestRestrictionConversionRedecidesInsideTheTransaction` 复现了这个竞态。**它需要一个测试缝隙**：一个在生产环境下为 nil 的 `testHookBeforeRestrictionTx` 函数变量，让测试能恰好在预览与事务之间的那个窗口里创建冲突主题。我确认过它值得存在——针对修复前的逻辑，这个测试会以 `conversion result = <nil>` 失败，也就是转换静默成功、坏掉的主题存活了下来。如果你不希望生产代码里有测试钩子，说一声，我会删掉钩子和测试，只保留修复。

## `fix: reindex topics converted by a category restriction`

转换重写了 `topics.category_ids` 和 `topic_category_index`，却完全没有触碰 Meilisearch。在 `keep_category` 策略下，主题最终只属于受限分类，而它的搜索文档仍然带着原来的公开分类 id，于是访客搜索依然能搜到它。所有 SQL 路径本身都是对的，这正是它容易被忽略的原因。

被转换的主题现在会在事务提交之后重建索引，绝不在事务内——搜索索引无法跟数据库一起回滚，所以提前重建比延后重建更糟。

重建走的是一个 `rebuildTopicSearchDocument` 函数变量，好让测试在没有 Meilisearch 的情况下也能观察到它。这一个属于普通的间接层而不是测试钩子，但它毕竟还是个变量，你也可能不喜欢。

## 本 PR 没有解决的一点

在事务提交之后、`accesscontrol.InvalidateGroup` 执行之前，存在一个残留窗口。单实例下它只有几微秒。多实例下它最长是 `metadataTTL`——两分钟——因为权限快照缓存是进程内的，失效并不会在实例之间传播。在这个窗口里，另一个实例仍然认为该分类是公开的，并且会欣然接受一个新的 `[公开, 受限]` 主题。

我没有在这里尝试修它：那需要跨实例失效机制，或者一个周期性的修复任务，两者都是比"阻塞项修复"更大的决定，不该夹带进来。但它值得知道，而且它正是那个一般形态的一个真实（虽然很小的）例子——在这个模型里，主题的可见性派生自可以在它脚下改变的状态。

## 验证

`go build ./...` 通过，`go vet` 通过，完整的 `go test ./...` 全部通过。两个新测试都验证过：针对修复前的代码它们会失败，而不只是修复后能通过。
