### PR TITLE
fix: hide restricted auxiliary categories from topic pages

### DIFF
--- a/app/http/controllers/forum/category.go
+++ b/app/http/controllers/forum/category.go
@@ -43,7 +43,7 @@ func Category(c *gin.Context) {
 
 	payload := PagePayload{
 		Component: PageComponentCategory,
-		Props:     buildCategoryPageProps(component.LoginUserId(c), category, page, sort, topicPage.Topics, topicPage.HasNext),
+		Props:     buildCategoryPageProps(snapshot, component.LoginUserId(c), category, page, sort, topicPage.Topics, topicPage.HasNext),
 		Meta:      buildCategoryMeta(c, category, page, sort, topicPage.HasNext),
 		Layout:    buildLayout(c, "category_"+cast.ToString(category.Id)),
 		URL:       buildPageURL(c),

--- a/app/http/controllers/forum/home.go
+++ b/app/http/controllers/forum/home.go
@@ -27,7 +27,7 @@ func Home(c *gin.Context) {
 	)
 	payload := PagePayload{
 		Component: PageComponentHome,
-		Props:     buildHomeProps(component.LoginUserId(c), page, sort, topicPage.Topics, topicPage.HasNext),
+		Props:     buildHomeProps(snapshot, component.LoginUserId(c), page, sort, topicPage.Topics, topicPage.HasNext),
 		Meta:      buildHomeMeta(c, page, sort, topicPage.HasNext),
 		Layout:    buildLayout(c, activeKeyForHome(sort)),
 		URL:       buildPageURL(c),

--- a/app/http/controllers/forum/payload.go
+++ b/app/http/controllers/forum/payload.go
@@ -747,7 +747,7 @@ func buildChromeNavItems(items []pageConfig.ChromeItem) []NavItemPayload {
 	return result
 }
 
-func buildHomeProps(userID uint64, page int, sort string, topics []*vo.TopicsSimpleVo, hasNext bool) HomeProps {
+func buildHomeProps(snapshot accesscontrol.Snapshot, userID uint64, page int, sort string, topics []*vo.TopicsSimpleVo, hasNext bool) HomeProps {
 	nextPage := 0
 	if hasNext {
 		nextPage = page + 1
@@ -757,7 +757,7 @@ func buildHomeProps(userID uint64, page int, sort string, topics []*vo.TopicsSim
 	return HomeProps{
 		Sort:   sort,
 		Tabs:   buildHomeTabs(sort),
-		Topics: buildTrackedTopicPayloads(userID, topics),
+		Topics: buildTrackedTopicPayloads(snapshot, userID, topics),
 		Pagination: PaginationPayload{
 			Page:     page,
 			NextPage: nextPage,
@@ -772,8 +772,8 @@ func buildHomeProps(userID uint64, page int, sort string, topics []*vo.TopicsSim
 	}
 }
 
-func buildTrackedTopicPayloads(userID uint64, topics []*vo.TopicsSimpleVo) []TopicPayload {
-	payloads := buildTopicPayloads(topics)
+func buildTrackedTopicPayloads(snapshot accesscontrol.Snapshot, userID uint64, topics []*vo.TopicsSimpleVo) []TopicPayload {
+	payloads := applyCategoryVisibility(snapshot, buildTopicPayloads(topics))
 	if userID == 0 || len(payloads) == 0 {
 		return payloads
 	}
@@ -1182,7 +1182,7 @@ func buildTopicHotTopics(c *gin.Context, currentTopicID uint64) []TopicPayload {
 			break
 		}
 	}
-	return buildTopicPayloads(filtered)
+	return applyCategoryVisibility(cachedAccessSnapshot(c), buildTopicPayloads(filtered))
 }
 
 func buildTopicDetailPayload(c *gin.Context, topic *topics.Entity, firstPost *posts.Entity, userMap map[uint64]*users.EntityComplete) TopicDetailPayload {
@@ -1235,7 +1235,7 @@ func buildTopicDetailPayload(c *gin.Context, topic *topics.Entity, firstPost *po
 		ProcessStatus: topic.ProcessStatus,
 		Author:        authorPayload(topic.UserId),
 		Participants:  participants,
-		Categories:    categoryPayloads(topic.CategoryIds),
+		Categories:    readableCategoryPayloads(cachedAccessSnapshot(c), topic.CategoryIds),
 		ReplyCount:    topic.ReplyCount,
 		MaxPostNo:     topic.PostSeq,
 		ViewCount:     topic.ViewCount,
@@ -1246,6 +1246,40 @@ func buildTopicDetailPayload(c *gin.Context, topic *topics.Entity, firstPost *po
 		CreatedAt:     createdAt.Format(time.DateTime),
 		UpdatedAt:     updatedAt.Format(time.DateTime),
 	}
+}
+
+// readableCategoryPayloads hides auxiliary categories the viewer cannot read.
+// Only the main category decides who may read a topic, so a public topic can
+// carry restricted auxiliary categories; rendering those would disclose their
+// name, id and URL to everyone, and buildTopicMeta would additionally publish
+// them as SEO keywords and article tags. The main category is always kept: the
+// handler has already required read on it before rendering the page, so it is
+// readable by construction, and dropping it would empty the breadcrumb and the
+// page metadata.
+func readableCategoryPayloads(snapshot accesscontrol.Snapshot, ids []uint64) []TopicCategoryPayload {
+	return readableCategories(snapshot, categoryPayloads(ids))
+}
+
+// readableCategories drops every category after the first that the viewer cannot
+// read. See readableCategoryPayloads for why the first one is exempt.
+func readableCategories(snapshot accesscontrol.Snapshot, payloads []TopicCategoryPayload) []TopicCategoryPayload {
+	visible := make([]TopicCategoryPayload, 0, len(payloads))
+	for index, payload := range payloads {
+		if index == 0 || snapshot.CanReadCategory(payload.ID) {
+			visible = append(visible, payload)
+		}
+	}
+	return visible
+}
+
+// applyCategoryVisibility hides restricted auxiliary categories on list cards.
+// A list only contains topics whose main category the viewer can read, but those
+// topics may still carry auxiliary categories that they cannot.
+func applyCategoryVisibility(snapshot accesscontrol.Snapshot, payloads []TopicPayload) []TopicPayload {
+	for index := range payloads {
+		payloads[index].Categories = readableCategories(snapshot, payloads[index].Categories)
+	}
+	return payloads
 }
 
 func categoryPayloads(ids []uint64) []TopicCategoryPayload {
@@ -1508,7 +1542,7 @@ func buildUserProfileProps(c *gin.Context, snapshot accesscontrol.Snapshot, user
 			if hasNext {
 				topicPage = topicPage[:userProfileTopicPageSize]
 			}
-			topicPayloads = buildTopicPayloads(transform.Topics2Vo(topicPage, hotdataserve.CategoryMap()))
+			topicPayloads = applyCategoryVisibility(snapshot, buildTopicPayloads(transform.Topics2Vo(topicPage, hotdataserve.CategoryMap())))
 			pagination = buildUserActivityTopicPagination(user.Id, topicPage, hasNext)
 		case userProfileActivityLikes:
 			refs, nextCursor := topicUserAction.ListLikedTopicRefsBeforeForAudience(user.Id, c.Query("cursor"), userProfileTimelinePageSize, snapshot.ReadableCategoryIDs(), !snapshot.HasGlobalManage())
@@ -1533,7 +1567,7 @@ func buildUserProfileProps(c *gin.Context, snapshot accesscontrol.Snapshot, user
 	default:
 		badges = userBadges
 		latestTopics, _ := topics.GetLatestPublishedByUserIdForAudience(user.Id, 8, snapshot.ReadableCategoryIDs(), !snapshot.HasGlobalManage())
-		topicPayloads = buildTopicPayloads(transform.Topics2Vo(latestTopics, hotdataserve.CategoryMap()))
+		topicPayloads = applyCategoryVisibility(snapshot, buildTopicPayloads(transform.Topics2Vo(latestTopics, hotdataserve.CategoryMap())))
 		timeline, _ := userActivities.GetUserTimelineForAudience(user.Id, 0, 5, snapshot.ReadableCategoryIDs(), !snapshot.HasGlobalManage())
 		activities = buildUserActivities(timeline)
 	}
@@ -1800,7 +1834,7 @@ func buildUserMeta(c *gin.Context, user *vo.UserCard) PageMeta {
 	return meta
 }
 
-func buildCategoryPageProps(userID uint64, category *category.Entity, page int, sort string, topics []*vo.TopicsSimpleVo, hasNext bool) CategoryPageProps {
+func buildCategoryPageProps(snapshot accesscontrol.Snapshot, userID uint64, category *category.Entity, page int, sort string, topics []*vo.TopicsSimpleVo, hasNext bool) CategoryPageProps {
 	nextPage := 0
 	if hasNext {
 		nextPage = page + 1
@@ -1816,7 +1850,7 @@ func buildCategoryPageProps(userID uint64, category *category.Entity, page int, 
 		},
 		Sort:   sort,
 		Tabs:   buildCategoryTabs(category, sort),
-		Topics: buildTrackedTopicPayloads(userID, topics),
+		Topics: buildTrackedTopicPayloads(snapshot, userID, topics),
 		Pagination: PaginationPayload{
 			Page:     page,
 			NextPage: nextPage,
@@ -2276,7 +2310,7 @@ func buildSearchPageProps(c *gin.Context, query string, page int) SearchPageProp
 		nextPage = page + 1
 	}
 
-	props.Topics = buildTopicPayloads(transform.Topics2Vo(orderedTopics, hotdataserve.CategoryMap()))
+	props.Topics = applyCategoryVisibility(snapshot, buildTopicPayloads(transform.Topics2Vo(orderedTopics, hotdataserve.CategoryMap())))
 	props.Total = result.Total
 	props.TotalPages = totalPageCount
 	props.Pagination = PaginationPayload{

--- a/app/http/controllers/forum/topic_category_visibility_test.go
+++ b/app/http/controllers/forum/topic_category_visibility_test.go
@@ -1,0 +1,121 @@
+package forum
+
+import (
+	"testing"
+
+	"github.com/leancodebox/GooseForum/app/bundles/connect/dbconnect"
+	"github.com/leancodebox/GooseForum/app/models/forum/category"
+	"github.com/leancodebox/GooseForum/app/models/hotdataserve"
+	"github.com/leancodebox/GooseForum/app/service/accesscontrol"
+)
+
+// A public main category may carry restricted auxiliary categories, so the topic
+// detail payload must not disclose the auxiliary ones to a viewer who cannot read
+// them: their name and URL would render on the page, and buildTopicMeta would
+// publish the name as an SEO keyword and an article tag.
+func TestReadableCategoryPayloadsHidesRestrictedAuxiliaryCategories(t *testing.T) {
+	const (
+		publicCategoryID     = uint64(994301)
+		restrictedCategoryID = uint64(994302)
+		restrictedName       = "Restricted auxiliary"
+	)
+
+	ensureForumTestAccessCategory(t, publicCategoryID)
+	ensureForumTestAccessCategory(t, restrictedCategoryID)
+	renameForumTestCategory(t, publicCategoryID, "Public main")
+	renameForumTestCategory(t, restrictedCategoryID, restrictedName)
+	revokeForumTestEveryoneRead(t, restrictedCategoryID)
+
+	guest, err := accesscontrol.Resolve(0)
+	if err != nil {
+		t.Fatalf("resolve guest snapshot: %v", err)
+	}
+	if guest.CanReadCategory(restrictedCategoryID) {
+		t.Fatal("test setup: guests must not be able to read the restricted category")
+	}
+
+	payloads := readableCategoryPayloads(guest, []uint64{publicCategoryID, restrictedCategoryID})
+
+	if len(payloads) != 1 {
+		t.Fatalf("expected only the readable category, got %#v", payloads)
+	}
+	if payloads[0].ID != publicCategoryID {
+		t.Fatalf("expected the public main category, got %#v", payloads[0])
+	}
+	for _, payload := range payloads {
+		if payload.Name == restrictedName {
+			t.Fatalf("restricted auxiliary category name leaked to a guest: %#v", payload)
+		}
+	}
+}
+
+// The main category is exempt from the filter. The handler requires read on it
+// before rendering the page (forum.Topic), so it is readable by construction, and
+// dropping it would empty the breadcrumb and the page metadata.
+func TestReadableCategoryPayloadsKeepsMainCategory(t *testing.T) {
+	const (
+		restrictedCategoryID = uint64(994311)
+		publicCategoryID     = uint64(994312)
+	)
+
+	ensureForumTestAccessCategory(t, restrictedCategoryID)
+	ensureForumTestAccessCategory(t, publicCategoryID)
+	renameForumTestCategory(t, restrictedCategoryID, "Restricted main")
+	renameForumTestCategory(t, publicCategoryID, "Public auxiliary")
+	revokeForumTestEveryoneRead(t, restrictedCategoryID)
+
+	guest, err := accesscontrol.Resolve(0)
+	if err != nil {
+		t.Fatalf("resolve guest snapshot: %v", err)
+	}
+
+	payloads := readableCategoryPayloads(guest, []uint64{restrictedCategoryID, publicCategoryID})
+
+	if len(payloads) != 2 || payloads[0].ID != restrictedCategoryID {
+		t.Fatalf("expected the main category to be kept first, got %#v", payloads)
+	}
+}
+
+// A list only contains topics whose main category the viewer can read, but those
+// topics may still carry restricted auxiliary categories, so the cards need the
+// same filter as the detail page.
+func TestApplyCategoryVisibilityHidesRestrictedAuxiliaryCategoriesOnCards(t *testing.T) {
+	const (
+		publicCategoryID     = uint64(994321)
+		restrictedCategoryID = uint64(994322)
+	)
+
+	ensureForumTestAccessCategory(t, publicCategoryID)
+	ensureForumTestAccessCategory(t, restrictedCategoryID)
+	revokeForumTestEveryoneRead(t, restrictedCategoryID)
+
+	guest, err := accesscontrol.Resolve(0)
+	if err != nil {
+		t.Fatalf("resolve guest snapshot: %v", err)
+	}
+
+	payloads := applyCategoryVisibility(guest, []TopicPayload{{
+		ID: 1,
+		Categories: []TopicCategoryPayload{
+			{ID: publicCategoryID, Name: "Public main"},
+			{ID: restrictedCategoryID, Name: "Restricted auxiliary"},
+		},
+	}})
+
+	if len(payloads) != 1 {
+		t.Fatalf("expected the card to survive, got %#v", payloads)
+	}
+	if len(payloads[0].Categories) != 1 || payloads[0].Categories[0].ID != publicCategoryID {
+		t.Fatalf("restricted auxiliary category leaked on a list card: %#v", payloads[0].Categories)
+	}
+}
+
+func renameForumTestCategory(t *testing.T, categoryID uint64, name string) {
+	t.Helper()
+	conn := dbconnect.Connect()
+	if err := conn.Model(&category.Entity{}).Where("id = ?", categoryID).Update("name", name).Error; err != nil {
+		t.Fatalf("rename test category: %v", err)
+	}
+	hotdataserve.ClearCategoryCache()
+	t.Cleanup(hotdataserve.ClearCategoryCache)
+}


### PR DESCRIPTION
## What this fixes

Since the main-category model landed, only `topics.main_category_id` decides who may read a topic. Auxiliary categories are tags with no effect on visibility, which means this is now a legal and reasonable configuration:

```
topic.category_ids = [Public announcements, Internal pricing]
                      ^ main, decides visibility
```

The topic is public, and correctly so. But nothing filtered the rendered category list, so the topic detail page — and every list card — showed **both** categories to every viewer, including guests: name, id, colour and a clickable URL for a category they cannot read.

The lists are worth spelling out: they already only contain topics whose *main* category the viewer can read, which is why this was easy to miss. The auxiliary tags printed on those cards were never filtered.

Clicking is safe — `forum.Category` already requires `CanReadCategory` and sends guests to the login page — so no content escapes. What escapes is the existence and the name of the category.

It also reaches crawlers. `buildTopicMeta` maps the payload categories into `Keywords` and `article:tag`, so the name of a restricted category attached to any public topic was served in the page metadata and indexed.

## The change

`readableCategories` drops auxiliary categories the viewer cannot read. It is applied to the detail payload and, through `applyCategoryVisibility`, to the cards on the home, category, profile, search and hot-topic lists.

It always uses a snapshot the handler already resolved for the request — passed down as a parameter, or read back with `cachedAccessSnapshot` — so no payload builder resolves access on its own.

The main category is kept unconditionally. `forum.Topic` requires read on it before the page renders, so it is readable by construction; filtering it as well would only add a way for the breadcrumb and the page metadata to come out empty if a future caller forgot to seed the snapshot.

The moderation payloads (`moderationLogCategories`, the report items) keep the unfiltered helper on purpose: moderators are scoped by moderation permission and need to see the real categories of what they are reviewing.

## Tests

- `TestReadableCategoryPayloadsHidesRestrictedAuxiliaryCategories` — a guest looking at a topic whose main category is public and whose auxiliary category is restricted gets only the public one, and the restricted name is absent.
- `TestReadableCategoryPayloadsKeepsMainCategory` — the main category survives the filter even when it is the restricted one. This also keeps the first test honest: it proves the restricted category really is in the category cache and really would render, so the first test is not passing because the fixture is missing.
- `TestApplyCategoryVisibilityHidesRestrictedAuxiliaryCategoriesOnCards` — the same filter on a list card.

`go build ./...`, `go vet`, and `go test ./...` pass.

## Note

If the single-select invariant discussed in #12 is ever adopted, a public topic can no longer carry a restricted auxiliary category and this leak becomes unreachable. The filter is cheap and fail-safe, so it is worth having either way — it just becomes belt and braces.
